### PR TITLE
Minor bug fixes

### DIFF
--- a/examples/declarative-pipeline-regular-agents.groovy
+++ b/examples/declarative-pipeline-regular-agents.groovy
@@ -12,7 +12,7 @@ kind: Pod
 spec:
   containers:
     - name: maven
-      image: maven:3.3.9-jdk-8-alpine
+      image: maven:3.6.3-adoptopenjdk-11
       command:
       - cat
       tty: true

--- a/examples/declarative-pipeline-spot-agents.groovy
+++ b/examples/declarative-pipeline-spot-agents.groovy
@@ -12,7 +12,7 @@ kind: Pod
 spec:
   containers:
     - name: maven
-      image: maven:3.3.9-jdk-8-alpine
+      image: maven:3.6.3-adoptopenjdk-11
       command:
       - cat
       tty: true

--- a/templates/cloudbees-ci-workload.template.yaml
+++ b/templates/cloudbees-ci-workload.template.yaml
@@ -67,4 +67,4 @@ Resources:
 
 Outputs:
   CloudBeesCoreURL:
-    Value: !Sub "https://${CloudBeesCoreURL.Response}/cjoc"
+    Value: !Sub "http://${CloudBeesCoreURL.Response}/cjoc"


### PR DESCRIPTION
- Use of `https` in output URL creates confusion in our getting started wizard (QS does not enable TLS OOTB)
- Examples check out and build Spring Petclinic, which requires JDK9+ now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
