### PR TITLE
Revert "enable ALB"

### DIFF
--- a/templates/cloudbees-ci-workload.template.yaml
+++ b/templates/cloudbees-ci-workload.template.yaml
@@ -23,12 +23,10 @@ Resources:
       #Version: 3.16.1+a3fdb4ae4e87 # uncomment to use something other than latest
       Name: cloudbees-core
       ValueYaml: !Sub |
+        ingress-nginx:
+          Enabled: true
         OperationsCenter:
           Platform: eks
-          Ingress:
-            Class: alb
-            Annotations:
-              alb.ingress.kubernetes.io/scheme: internet-facing
           ExtraConfigMaps:
           - name: cloudbees-referrer
             labels:
@@ -64,7 +62,7 @@ Resources:
     Properties:
       ClusterName: !Ref EKSClusterName
       Namespace: default
-      Name: 'ingress/cjoc'
+      Name: 'service/cloudbees-core-ingress-nginx-controller'
       JsonPath: '{.status.loadBalancer.ingress[0].hostname}'
 
 Outputs:


### PR DESCRIPTION
This reverts commit b35bc584cfe7bde81639f68848b024a529e4b925.

*Description of changes:*
Resolves a last-mile deployment issue where the "workload" stack isn't created successfully. The `CloudBeesCoreURL` stack times out because the URL isn't available.

Switching back to ELB for now, to fix the immediate issue, then we can revisit ALB at a later date.

cc @jaymccon 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
